### PR TITLE
Add custom OpenSSL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <p>
   <img src="https://img.shields.io/badge/openresty-1.21.4.2-green.svg?style=for-the-badge">
+  <img src="https://img.shields.io/badge/openssl-3-1-2-green.svg?style=for-the-badge">
   <img src="https://img.shields.io/badge/lua-5.1.5-green.svg?style=for-the-badge">
   <img src="https://img.shields.io/badge/luarocks-3.3.1-green.svg?style=for-the-badge">
   <a href="https://hub.docker.com/repository/docker/jc21/nginx-full">
@@ -18,6 +19,7 @@ The following images are built:
 
 **latest**
 - OpenResty
+- OpenSSL
 - Lua
 - [Crowdsec Openresty Bouncer](https://github.com/crowdsecurity/cs-openresty-bouncer)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@
 FROM debian:buster-slim as nginxbuilder
 
 ARG OPENRESTY_VERSION
+ARG OPENSSL_VERSION
 ARG LUA_VERSION
 ARG LUAROCKS_VERSION
 
@@ -70,6 +71,10 @@ COPY ./files/.bashrc /root/.bashrc
 COPY --from=nginxbuilder /tmp/lua /tmp/lua
 COPY --from=nginxbuilder /tmp/luarocks /tmp/luarocks
 COPY ./scripts/install-lua /tmp/install-lua
+
+# Copy openssl build from first image
+COPY --from=nginxbuilder /usr/local/ssl /usr/local/ssl
+RUN echo "/usr/local/ssl/lib64" > /etc/ld.so.conf.d/openssl.conf && ldconfig
 
 # Copy openresty build from first image
 COPY --from=nginxbuilder /tmp/openresty /tmp/openresty

--- a/local-build.sh
+++ b/local-build.sh
@@ -9,6 +9,7 @@ RESET='\E[0m'
 DOCKER_IMAGE=jc21/nginx-full
 
 export OPENRESTY_VERSION=1.21.4.2
+export OPENSSL_VERSION=3.1.2
 export CROWDSEC_OPENRESTY_BOUNCER_VERSION=0.1.7
 export LUA_VERSION=5.1.5
 export LUAROCKS_VERSION=3.3.1
@@ -19,6 +20,7 @@ echo -e "${BLUE}❯ ${CYAN}Building ${YELLOW}latest ${CYAN}...${RESET}"
 docker build \
 	--pull \
 	--build-arg OPENRESTY_VERSION \
+	--build-arg OPENSSL_VERSION \
 	--build-arg CROWDSEC_OPENRESTY_BOUNCER_VERSION \
 	--build-arg LUA_VERSION \
 	--build-arg LUAROCKS_VERSION \

--- a/scripts/build-openresty
+++ b/scripts/build-openresty
@@ -6,6 +6,22 @@ YELLOW='\E[1;33m'
 GREEN='\E[1;32m'
 RESET='\E[0m'
 
+
+echo -e "${BLUE}❯ ${CYAN}Building OpenSSL ${YELLOW}${OPENSSL_VERSION}...${RESET}"
+
+cd /usr/src
+wget https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz && \
+  wget https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz.sha256
+
+echo "`cat openssl-${OPENSSL_VERSION}.tar.gz.sha256 | sed "s/ //g"` *openssl-${OPENSSL_VERSION}.tar.gz" | shasum -a 256 --check || exit -1
+
+tar -xzf openssl-${OPENSSL_VERSION}.tar.gz && cd openssl-${OPENSSL_VERSION} && \
+  ./Configure -d --prefix=/usr/local/ssl --openssldir=/usr/local/ssl '-Wl,-rpath,$(LIBRPATH)' shared && \
+    make && make install
+
+echo -e "${BLUE}❯ ${GREEN}OpenSSL build completed${RESET}"
+
+
 echo -e "${BLUE}❯ ${CYAN}Building OpenResty ${YELLOW}${OPENRESTY_VERSION}...${RESET}"
 
 cd /tmp
@@ -15,6 +31,8 @@ mv /tmp/openresty-${OPENRESTY_VERSION} /tmp/openresty
 cd /tmp/openresty
 
 ./configure \
+        --with-cc-opt='-I/usr/local/ssl/include' \
+        --with-ld-opt='-L/usr/local/ssl/lib64' \
 	--prefix=/etc/nginx \
 	--sbin-path=/usr/sbin/nginx \
 	--modules-path=/usr/lib/nginx/modules \

--- a/scripts/buildx
+++ b/scripts/buildx
@@ -23,6 +23,7 @@ docker buildx build \
 	--build-arg ACMESH_BASE_TAG \
 	--build-arg CERTBOT_BASE_TAG \
 	--build-arg OPENRESTY_VERSION \
+        --build-arg OPENSSL_VERSION \
 	--build-arg LUA_VERSION \
 	--build-arg LUAROCKS_VERSION \
 	--build-arg CROWDSEC_OPENRESTY_BOUNCER_VERSION \


### PR DESCRIPTION
This patch allows to download a custom version of OpenSSL and then build openresty against it; default version is ```OpenSSL 3.1.2 1 Aug 2023```

Fix: #5

@jc21 could you please review this patch?

----

Some tests:

```
root@docker:/usr/src/docker-nginx-full# docker run -it jc21/nginx-full /bin/bash
             _                  __       _ _ 
 _ __   __ _(_)_ __ __  __     / _|_   _| | |
| '_ \ / _` | | '_ \\ \/ /____| |_| | | | | |
| | | | (_| | | | | |>  <_____|  _| |_| | | |
|_| |_|\__, |_|_| |_/_/\_\    |_|  \__,_|_|_|
       |___/                                 
OpenResty 1.21.4.2, debian 10 (buster)
Base: debian:buster-slim, linux/amd64

[root@docker-413f2b1fa799:/]# /etc/nginx/bin/openresty -V
nginx version: openresty/1.21.4.2
built by gcc 8.3.0 (Debian 8.3.0-6) 
built with OpenSSL 3.1.2 1 Aug 2023
TLS SNI support enabled
configure arguments: --prefix=/etc/nginx/nginx --with-cc-opt='-O2 -I/usr/local/ssl/include' --add-module=../ngx_devel_kit-0.3.2 --add-module=../echo-nginx-module-0.63 --add-module=../xss-nginx-module-0.06 --add-module=../ngx_coolkit-0.2 --add-module=../set-misc-nginx-module-0.33 --add-module=../form-input-nginx-module-0.12 --add-module=../encrypted-session-nginx-module-0.09 --add-module=../srcache-nginx-module-0.33 --add-module=../ngx_lua-0.10.25 --add-module=../ngx_lua_upstream-0.07 --add-module=../headers-more-nginx-module-0.34 --add-module=../array-var-nginx-module-0.06 --add-module=../memc-nginx-module-0.19 --add-module=../redis2-nginx-module-0.15 --add-module=../redis-nginx-module-0.3.9 --add-module=../rds-json-nginx-module-0.16 --add-module=../rds-csv-nginx-module-0.09 --add-module=../ngx_stream_lua-0.0.13 --with-ld-opt='-Wl,-rpath,/etc/nginx/luajit/lib -L/usr/local/ssl/lib64' --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --pid-path=/var/run/nginx.pid --lock-path=/var/run/nginx.lock --http-client-body-temp-path=/var/cache/nginx/client_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp --http-scgi-temp-path=/var/cache/nginx/scgi_temp --user=nginx --group=nginx --with-compat --with-threads --with-http_addition_module --with-http_auth_request_module --with-http_dav_module --with-http_flv_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_mp4_module --with-http_random_index_module --with-http_realip_module --with-http_secure_link_module --with-http_slice_module --with-http_ssl_module --with-http_stub_status_module --with-http_sub_module --with-http_v2_module --with-mail --with-mail_ssl_module --with-stream --with-stream_realip_module --with-stream_ssl_module --with-stream_ssl_preread_module --with-stream
[root@docker-413f2b1fa799:/]#
[root@docker-413f2b1fa799:/]#
[root@docker-413f2b1fa799:/]#
[root@docker-413f2b1fa799:/]# /usr/local/ssl/bin/openssl version
OpenSSL 3.1.2 1 Aug 2023 (Library: OpenSSL 3.1.2 1 Aug 2023)
[root@docker-413f2b1fa799:/]#
[root@docker-413f2b1fa799:/]#
[root@docker-413f2b1fa799:/]#
[root@docker-413f2b1fa799:/]# /usr/local/ssl/bin/openssl speed  
Doing md5 for 3s on 16 size blocks: 11601406 md5's in 3.00s
Doing md5 for 3s on 64 size blocks: 8675469 md5's in 3.01s
Doing md5 for 3s on 256 size blocks: 4802764 md5's in 3.00s
Doing md5 for 3s on 1024 size blocks: 1748817 md5's in 2.99s
Doing md5 for 3s on 8192 size blocks: 252031 md5's in 3.01s
Doing md5 for 3s on 16384 size blocks: 126597 md5's in 3.00s
Doing sha1 for 3s on 16 size blocks: 10353470 sha1's in 3.00s
Doing sha1 for 3s on 64 size blocks: 7736491 sha1's in 3.00s
Doing sha1 for 3s on 256 size blocks: 4626620 sha1's in 3.00s
Doing sha1 for 3s on 1024 size blocks: 1809711 sha1's in 3.00s
Doing sha1 for 3s on 8192 size blocks: 273224 sha1's in 3.00s
Doing sha1 for 3s on 16384 size blocks: 138285 sha1's in 3.00s
Doing sha256 for 3s on 16 size blocks: 7303845 sha256's in 2.99s
Doing sha256 for 3s on 64 size blocks: 4920459 sha256's in 2.99s
Doing sha256 for 3s on 256 size blocks: 2522027 sha256's in 3.00s
Doing sha256 for 3s on 1024 size blocks: 861352 sha256's in 2.97s
Doing sha256 for 3s on 8192 size blocks: 119989 sha256's in 3.00s
Doing sha256 for 3s on 16384 size blocks: 60694 sha256's in 3.01s
Doing sha512 for 3s on 16 size blocks: 6230304 sha512's in 2.99s
Doing sha512 for 3s on 64 size blocks: 6225928 sha512's in 3.00s
Doing sha512 for 3s on 256 size blocks: 3023029 sha512's in 3.00s
Doing sha512 for 3s on 1024 size blocks: 1210424 sha512's in 3.00s
Doing sha512 for 3s on 8192 size blocks: 183489 sha512's in 3.00s
Doing sha512 for 3s on 16384 size blocks: 93334 sha512's in 3.00s
Doing rmd160 for 3s on 16 size blocks: 4860621 rmd160's in 2.99s
Doing rmd160 for 3s on 64 size blocks: 2836319 rmd160's in 3.00s
Doing rmd160 for 3s on 256 size blocks: 1267634 rmd160's in 3.00s
Doing rmd160 for 3s on 1024 size blocks: 395420 rmd160's in 3.01s
Doing rmd160 for 3s on 8192 size blocks: 53104 rmd160's in 3.00s
Doing rmd160 for 3s on 16384 size blocks: 26717 rmd160's in 3.00s
Doing hmac(md5) for 3s on 16 size blocks: 6236379 hmac(md5)'s in 3.01s
Doing hmac(md5) for 3s on 64 size blocks: 5290259 hmac(md5)'s in 3.00s
Doing hmac(md5) for 3s on 256 size blocks: 3571452 hmac(md5)'s in 2.99s
Doing hmac(md5) for 3s on 1024 size blocks: 1543192 hmac(md5)'s in 2.99s
Doing hmac(md5) for 3s on 8192 size blocks: 245791 hmac(md5)'s in 3.00s
Doing hmac(md5) for 3s on 16384 size blocks: 125340 hmac(md5)'s in 3.00s
Doing des-ede3 for 3s on 16 size blocks: 3271201 des-ede3's in 2.98s
Doing des-ede3 for 3s on 64 size blocks: 835241 des-ede3's in 3.00s
Doing des-ede3 for 3s on 256 size blocks: 209426 des-ede3's in 3.00s
Doing des-ede3 for 3s on 1024 size blocks: 52673 des-ede3's in 3.01s
Doing des-ede3 for 3s on 8192 size blocks: 6562 des-ede3's in 3.00s
Doing des-ede3 for 3s on 16384 size blocks: 3282 des-ede3's in 3.00s
Doing aes-128-cbc for 3s on 16 size blocks: 152241487 aes-128-cbc's in 3.00s
Doing aes-128-cbc for 3s on 64 size blocks: 73360244 aes-128-cbc's in 3.01s
Doing aes-128-cbc for 3s on 256 size blocks: 18794071 aes-128-cbc's in 2.99s
Doing aes-128-cbc for 3s on 1024 size blocks: 4750017 aes-128-cbc's in 2.99s
Doing aes-128-cbc for 3s on 8192 size blocks: 593684 aes-128-cbc's in 3.00s
Doing aes-128-cbc for 3s on 16384 size blocks: 296353 aes-128-cbc's in 3.00s
Doing aes-192-cbc for 3s on 16 size blocks: 146599250 aes-192-cbc's in 3.00s
Doing aes-192-cbc for 3s on 64 size blocks: 62650062 aes-192-cbc's in 3.00s
Doing aes-192-cbc for 3s on 256 size blocks: 15983055 aes-192-cbc's in 3.00s
Doing aes-192-cbc for 3s on 1024 size blocks: 4016135 aes-192-cbc's in 2.99s
Doing aes-192-cbc for 3s on 8192 size blocks: 502721 aes-192-cbc's in 3.00s
Doing aes-192-cbc for 3s on 16384 size blocks: 251358 aes-192-cbc's in 3.00s
Doing aes-256-cbc for 3s on 16 size blocks: 142349230 aes-256-cbc's in 3.00s
Doing aes-256-cbc for 3s on 64 size blocks: 54387934 aes-256-cbc's in 3.00s
Doing aes-256-cbc for 3s on 256 size blocks: 13854139 aes-256-cbc's in 2.99s
Doing aes-256-cbc for 3s on 1024 size blocks: 3479543 aes-256-cbc's in 2.99s
Doing aes-256-cbc for 3s on 8192 size blocks: 435373 aes-256-cbc's in 2.99s
Doing aes-256-cbc for 3s on 16384 size blocks: 217274 aes-256-cbc's in 3.00s
Doing camellia-128-cbc for 3s on 16 size blocks: 19437669 camellia-128-cbc's in 2.99s
Doing camellia-128-cbc for 3s on 64 size blocks: 7332403 camellia-128-cbc's in 3.00s
Doing camellia-128-cbc for 3s on 256 size blocks: 2104930 camellia-128-cbc's in 3.01s
Doing camellia-128-cbc for 3s on 1024 size blocks: 545972 camellia-128-cbc's in 3.00s
Doing camellia-128-cbc for 3s on 8192 size blocks: 68970 camellia-128-cbc's in 2.99s
Doing camellia-128-cbc for 3s on 16384 size blocks: 34625 camellia-128-cbc's in 3.01s
Doing camellia-192-cbc for 3s on 16 size blocks: 16374043 camellia-192-cbc's in 3.00s
Doing camellia-192-cbc for 3s on 64 size blocks: 5739049 camellia-192-cbc's in 2.99s
Doing camellia-192-cbc for 3s on 256 size blocks: 1592435 camellia-192-cbc's in 3.00s
Doing camellia-192-cbc for 3s on 1024 size blocks: 409932 camellia-192-cbc's in 3.00s
Doing camellia-192-cbc for 3s on 8192 size blocks: 51547 camellia-192-cbc's in 2.99s
Doing camellia-192-cbc for 3s on 16384 size blocks: 25825 camellia-192-cbc's in 2.99s
Doing camellia-256-cbc for 3s on 16 size blocks: 16397071 camellia-256-cbc's in 3.00s
Doing camellia-256-cbc for 3s on 64 size blocks: 5754945 camellia-256-cbc's in 3.01s
Doing camellia-256-cbc for 3s on 256 size blocks: 1602513 camellia-256-cbc's in 3.01s
Doing camellia-256-cbc for 3s on 1024 size blocks: 410150 camellia-256-cbc's in 2.99s
Doing camellia-256-cbc for 3s on 8192 size blocks: 51994 camellia-256-cbc's in 3.01s
Doing camellia-256-cbc for 3s on 16384 size blocks: 26028 camellia-256-cbc's in 3.02s
Doing ghash for 3s on 16 size blocks: 88522238 ghash's in 2.99s
Doing ghash for 3s on 64 size blocks: 80856401 ghash's in 3.00s
Doing ghash for 3s on 256 size blocks: 60033886 ghash's in 2.99s
Doing ghash for 3s on 1024 size blocks: 28273369 ghash's in 3.00s
Doing ghash for 3s on 8192 size blocks: 4821281 ghash's in 3.01s
Doing ghash for 3s on 16384 size blocks: 2454113 ghash's in 3.00s
Doing rand for 3s on 16 size blocks: 2270710 rand's in 2.66s
Doing rand for 3s on 64 size blocks: 2282280 rand's in 2.65s
Doing rand for 3s on 256 size blocks: 2230867 rand's in 2.55s
Doing rand for 3s on 1024 size blocks: 2073031 rand's in 2.70s
Doing rand for 3s on 8192 size blocks: 1223162 rand's in 2.81s
Doing rand for 3s on 16384 size blocks: 836638 rand's in 2.89s
Doing 512 bits private rsa's for 10s: 138656 512 bits private RSA's in 9.98s
Doing 512 bits public rsa's for 10s: 2704483 512 bits public RSA's in 9.97s
Doing 1024 bits private rsa's for 10s: 70357 1024 bits private RSA's in 10.00s
Doing 1024 bits public rsa's for 10s: 995299 1024 bits public RSA's in 9.98s
Doing 2048 bits private rsa's for 10s: 15030 2048 bits private RSA's in 9.99s
Doing 2048 bits public rsa's for 10s: 291229 2048 bits public RSA's in 9.97s
Doing 3072 bits private rsa's for 10s: 3193 3072 bits private RSA's in 9.99s
Doing 3072 bits public rsa's for 10s: 144195 3072 bits public RSA's in 9.98s
Doing 4096 bits private rsa's for 10s: 1419 4096 bits private RSA's in 10.00s
Doing 4096 bits public rsa's for 10s: 83720 4096 bits public RSA's in 10.00s
Doing 7680 bits private rsa's for 10s: 148 7680 bits private RSA's in 9.99s
Doing 7680 bits public rsa's for 10s: 24928 7680 bits public RSA's in 10.00s
Doing 15360 bits private rsa's for 10s: 29 15360 bits private RSA's in 10.00s
Doing 15360 bits public rsa's for 10s: 6320 15360 bits public RSA's in 9.99s
Doing 512 bits sign dsa's for 10s: 89745 512 bits DSA signs in 9.97s
Doing 512 bits verify dsa's for 10s: 203324 512 bits DSA verify in 10.00s
Doing 1024 bits sign dsa's for 10s: 51185 1024 bits DSA signs in 9.99s
Doing 1024 bits verify dsa's for 10s: 86549 1024 bits DSA verify in 10.00s
Doing 2048 bits sign dsa's for 10s: 20349 2048 bits DSA signs in 9.99s
Doing 2048 bits verify dsa's for 10s: 26939 2048 bits DSA verify in 10.00s
Doing 160 bits sign ecdsa's for 10s: 32337 160 bits ECDSA signs in 9.99s
Doing 160 bits verify ecdsa's for 10s: 32768 160 bits ECDSA verify in 10.00s
Doing 192 bits sign ecdsa's for 10s: 26317 192 bits ECDSA signs in 9.98s
Doing 192 bits verify ecdsa's for 10s: 27817 192 bits ECDSA verify in 10.00s
Doing 224 bits sign ecdsa's for 10s: 18351 224 bits ECDSA signs in 10.00s
Doing 224 bits verify ecdsa's for 10s: 20118 224 bits ECDSA verify in 9.99s
Doing 256 bits sign ecdsa's for 10s: 330149 256 bits ECDSA signs in 9.90s
Doing 256 bits verify ecdsa's for 10s: 116147 256 bits ECDSA verify in 10.00s
Doing 384 bits sign ecdsa's for 10s: 7778 384 bits ECDSA signs in 9.99s
Doing 384 bits verify ecdsa's for 10s: 9386 384 bits ECDSA verify in 10.00s
Doing 521 bits sign ecdsa's for 10s: 3500 521 bits ECDSA signs in 10.00s
Doing 521 bits verify ecdsa's for 10s: 4486 521 bits ECDSA verify in 10.00s
Doing 163 bits sign ecdsa's for 10s: 17362 163 bits ECDSA signs in 9.99s
Doing 163 bits verify ecdsa's for 10s: 8673 163 bits ECDSA verify in 10.00s
Doing 233 bits sign ecdsa's for 10s: 11769 233 bits ECDSA signs in 10.00s
Doing 233 bits verify ecdsa's for 10s: 5913 233 bits ECDSA verify in 9.98s
Doing 283 bits sign ecdsa's for 10s: 7054 283 bits ECDSA signs in 9.99s
Doing 283 bits verify ecdsa's for 10s: 3515 283 bits ECDSA verify in 10.00s
Doing 409 bits sign ecdsa's for 10s: 4087 409 bits ECDSA signs in 9.99s
Doing 409 bits verify ecdsa's for 10s: 2048 409 bits ECDSA verify in 9.99s
Doing 571 bits sign ecdsa's for 10s: 1885 571 bits ECDSA signs in 10.00s
Doing 571 bits verify ecdsa's for 10s: 936 571 bits ECDSA verify in 10.01s
Doing 163 bits sign ecdsa's for 10s: 16657 163 bits ECDSA signs in 9.99s
Doing 163 bits verify ecdsa's for 10s: 8343 163 bits ECDSA verify in 9.98s
Doing 233 bits sign ecdsa's for 10s: 11396 233 bits ECDSA signs in 9.98s
Doing 233 bits verify ecdsa's for 10s: 5736 233 bits ECDSA verify in 9.96s
Doing 283 bits sign ecdsa's for 10s: 6741 283 bits ECDSA signs in 9.99s
Doing 283 bits verify ecdsa's for 10s: 3361 283 bits ECDSA verify in 9.98s
Doing 409 bits sign ecdsa's for 10s: 3832 409 bits ECDSA signs in 9.99s
Doing 409 bits verify ecdsa's for 10s: 1867 409 bits ECDSA verify in 9.99s
Doing 571 bits sign ecdsa's for 10s: 1703 571 bits ECDSA signs in 9.99s
Doing 571 bits verify ecdsa's for 10s: 862 571 bits ECDSA verify in 9.99s
Doing 256 bits sign ecdsa's for 10s: 16545 256 bits ECDSA signs in 9.97s
Doing 256 bits verify ecdsa's for 10s: 17374 256 bits ECDSA verify in 10.00s
Doing 256 bits sign ecdsa's for 10s: 16702 256 bits ECDSA signs in 9.99s
Doing 256 bits verify ecdsa's for 10s: 18229 256 bits ECDSA verify in 9.97s
Doing 384 bits sign ecdsa's for 10s: 7630 384 bits ECDSA signs in 9.99s
Doing 384 bits verify ecdsa's for 10s: 8842 384 bits ECDSA verify in 10.00s
Doing 384 bits sign ecdsa's for 10s: 7790 384 bits ECDSA signs in 10.00s
Doing 384 bits verify ecdsa's for 10s: 9218 384 bits ECDSA verify in 10.00s
Doing 512 bits sign ecdsa's for 10s: 4521 512 bits ECDSA signs in 9.99s
Doing 512 bits verify ecdsa's for 10s: 5542 512 bits ECDSA verify in 9.99s
Doing 512 bits sign ecdsa's for 10s: 4613 512 bits ECDSA signs in 9.99s
Doing 512 bits verify ecdsa's for 10s: 5714 512 bits ECDSA verify in 9.97s
Doing 160 bits  ecdh's for 10s: 32680 160-bits ECDH ops in 9.98s
Doing 192 bits  ecdh's for 10s: 24929 192-bits ECDH ops in 9.96s
Doing 224 bits  ecdh's for 10s: 18654 224-bits ECDH ops in 9.98s
Doing 256 bits  ecdh's for 10s: 152633 256-bits ECDH ops in 10.00s
Doing 384 bits  ecdh's for 10s: 8023 384-bits ECDH ops in 9.99s
Doing 521 bits  ecdh's for 10s: 3598 521-bits ECDH ops in 9.99s
Doing 163 bits  ecdh's for 10s: 16855 163-bits ECDH ops in 9.97s
Doing 233 bits  ecdh's for 10s: 11583 233-bits ECDH ops in 9.96s
Doing 283 bits  ecdh's for 10s: 7125 283-bits ECDH ops in 9.99s
Doing 409 bits  ecdh's for 10s: 4004 409-bits ECDH ops in 10.00s
Doing 571 bits  ecdh's for 10s: 1838 571-bits ECDH ops in 9.98s
Doing 163 bits  ecdh's for 10s: 16764 163-bits ECDH ops in 9.98s
Doing 233 bits  ecdh's for 10s: 11269 233-bits ECDH ops in 9.97s
Doing 283 bits  ecdh's for 10s: 6746 283-bits ECDH ops in 9.98s
Doing 409 bits  ecdh's for 10s: 3842 409-bits ECDH ops in 9.88s
Doing 571 bits  ecdh's for 10s: 1789 571-bits ECDH ops in 9.98s
Doing 256 bits  ecdh's for 10s: 17261 256-bits ECDH ops in 9.97s
Doing 256 bits  ecdh's for 10s: 17349 256-bits ECDH ops in 9.99s
Doing 384 bits  ecdh's for 10s: 7940 384-bits ECDH ops in 9.98s
Doing 384 bits  ecdh's for 10s: 7987 384-bits ECDH ops in 9.96s
Doing 512 bits  ecdh's for 10s: 4605 512-bits ECDH ops in 9.98s
Doing 512 bits  ecdh's for 10s: 4657 512-bits ECDH ops in 9.99s
Doing 253 bits  ecdh's for 10s: 161219 253-bits ECDH ops in 9.99s
Doing 448 bits  ecdh's for 10s: 11194 448-bits ECDH ops in 9.99s
Doing 253 bits sign Ed25519's for 10s: 71827 253 bits Ed25519 signs in 9.98s 
Doing 253 bits verify Ed25519's for 10s: 33863 253 bits Ed25519 verify in 9.99s
Doing 456 bits sign Ed448's for 10s: 4458 456 bits Ed448 signs in 9.99s 
Doing 456 bits verify Ed448's for 10s: 10452 456 bits Ed448 verify in 9.98s
Doing 256 bits sign CurveSM2's for 10s: 16340 256 bits CurveSM2 signs in 9.98s 
Doing 256 bits verify CurveSM2's for 10s: 17940 256 bits CurveSM2 verify in 9.99s
Doing 2048 bits  ffdh's for 10s: 17623 2048-bits FFDH ops in 10.00s
Doing 3072 bits  ffdh's for 10s: 7907 3072-bits FFDH ops in 9.99s
Doing 4096 bits  ffdh's for 10s: 3825 4096-bits FFDH ops in 9.99s
Doing 6144 bits  ffdh's for 10s: 1655 6144-bits FFDH ops in 10.00s
Doing 8192 bits  ffdh's for 10s: 813 8192-bits FFDH ops in 10.00s
version: 3.1.2
built on: Tue Aug 15 09:18:25 2023 UTC
options: bn(64,64)
compiler: gcc -fPIC -pthread -m64 -Wa,--noexecstack -Wall -O0 -g -DOPENSSL_USE_NODELETE -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL
CPUINFO: OPENSSL_ia32cap=0xdefa2203478bffff:0x842461
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
md5              61874.17k   184461.80k   409835.86k   598925.96k   685926.23k   691388.42k
sha1             55218.51k   165045.14k   394804.91k   617714.69k   746083.67k   755220.48k
rmd160           26010.01k    60508.14k   108171.43k   134521.62k   145009.32k   145910.44k
sha256           39084.12k   105320.86k   215212.97k   296977.93k   327649.96k   330368.94k
sha512           33339.42k   132819.80k   257965.14k   413158.06k   501047.30k   509728.09k
hmac(md5)        33150.19k   112858.86k   305783.18k   528504.55k   671173.29k   684523.52k
des-ede3         17563.50k    17818.47k    17871.02k    17919.32k    17918.63k    17924.10k
aes-128-cbc     811954.60k  1559819.14k  1609124.47k  1626761.67k  1621153.11k  1618482.52k
aes-192-cbc     781862.67k  1336534.66k  1363887.36k  1375425.50k  1372763.48k  1372749.82k
aes-256-cbc     759195.89k  1160275.93k  1186173.77k  1191656.20k  1192834.65k  1186605.74k
camellia-128-cbc   104014.28k   156424.60k   179023.95k   186358.44k   188963.96k   188470.43k
camellia-192-cbc    87328.23k   122842.52k   135887.79k   139923.46k   141228.44k   141510.64k
camellia-256-cbc    87451.05k   122364.28k   136293.46k   140466.09k   141506.59k   141206.21k
ghash           473697.59k  1724936.55k  5140025.02k  9650643.29k 13121572.74k 13402729.13k
rand             13658.41k    55119.22k   223961.55k   786216.20k  3565887.23k  4743071.62k
                  sign    verify    sign/s verify/s
rsa  512 bits 0.000072s 0.000004s  13893.4 271262.1
rsa 1024 bits 0.000142s 0.000010s   7035.7  99729.4
rsa 2048 bits 0.000665s 0.000034s   1504.5  29210.5
rsa 3072 bits 0.003129s 0.000069s    319.6  14448.4
rsa 4096 bits 0.007047s 0.000119s    141.9   8372.0
rsa 7680 bits 0.067500s 0.000401s     14.8   2492.8
rsa 15360 bits 0.344828s 0.001581s      2.9    632.6
                  sign    verify    sign/s verify/s
dsa  512 bits 0.000111s 0.000049s   9001.5  20332.4
dsa 1024 bits 0.000195s 0.000116s   5123.6   8654.9
dsa 2048 bits 0.000491s 0.000371s   2036.9   2693.9
                              sign    verify    sign/s verify/s
 160 bits ecdsa (secp160r1)   0.0003s   0.0003s   3236.9   3276.8
 192 bits ecdsa (nistp192)   0.0004s   0.0004s   2637.0   2781.7
 224 bits ecdsa (nistp224)   0.0005s   0.0005s   1835.1   2013.8
 256 bits ecdsa (nistp256)   0.0000s   0.0001s  33348.4  11614.7
 384 bits ecdsa (nistp384)   0.0013s   0.0011s    778.6    938.6
 521 bits ecdsa (nistp521)   0.0029s   0.0022s    350.0    448.6
 163 bits ecdsa (nistk163)   0.0006s   0.0012s   1737.9    867.3
 233 bits ecdsa (nistk233)   0.0008s   0.0017s   1176.9    592.5
 283 bits ecdsa (nistk283)   0.0014s   0.0028s    706.1    351.5
 409 bits ecdsa (nistk409)   0.0024s   0.0049s    409.1    205.0
 571 bits ecdsa (nistk571)   0.0053s   0.0107s    188.5     93.5
 163 bits ecdsa (nistb163)   0.0006s   0.0012s   1667.4    836.0
 233 bits ecdsa (nistb233)   0.0009s   0.0017s   1141.9    575.9
 283 bits ecdsa (nistb283)   0.0015s   0.0030s    674.8    336.8
 409 bits ecdsa (nistb409)   0.0026s   0.0054s    383.6    186.9
 571 bits ecdsa (nistb571)   0.0059s   0.0116s    170.5     86.3
 256 bits ecdsa (brainpoolP256r1)   0.0006s   0.0006s   1659.5   1737.4
 256 bits ecdsa (brainpoolP256t1)   0.0006s   0.0005s   1671.9   1828.4
 384 bits ecdsa (brainpoolP384r1)   0.0013s   0.0011s    763.8    884.2
 384 bits ecdsa (brainpoolP384t1)   0.0013s   0.0011s    779.0    921.8
 512 bits ecdsa (brainpoolP512r1)   0.0022s   0.0018s    452.6    554.8
 512 bits ecdsa (brainpoolP512t1)   0.0022s   0.0017s    461.8    573.1
                              op      op/s
 160 bits ecdh (secp160r1)   0.0003s   3274.5
 192 bits ecdh (nistp192)   0.0004s   2502.9
 224 bits ecdh (nistp224)   0.0005s   1869.1
 256 bits ecdh (nistp256)   0.0001s  15263.3
 384 bits ecdh (nistp384)   0.0012s    803.1
 521 bits ecdh (nistp521)   0.0028s    360.2
 163 bits ecdh (nistk163)   0.0006s   1690.6
 233 bits ecdh (nistk233)   0.0009s   1163.0
 283 bits ecdh (nistk283)   0.0014s    713.2
 409 bits ecdh (nistk409)   0.0025s    400.4
 571 bits ecdh (nistk571)   0.0054s    184.2
 163 bits ecdh (nistb163)   0.0006s   1679.8
 233 bits ecdh (nistb233)   0.0009s   1130.3
 283 bits ecdh (nistb283)   0.0015s    676.0
 409 bits ecdh (nistb409)   0.0026s    388.9
 571 bits ecdh (nistb571)   0.0056s    179.3
 256 bits ecdh (brainpoolP256r1)   0.0006s   1731.3
 256 bits ecdh (brainpoolP256t1)   0.0006s   1736.6
 384 bits ecdh (brainpoolP384r1)   0.0013s    795.6
 384 bits ecdh (brainpoolP384t1)   0.0012s    801.9
 512 bits ecdh (brainpoolP512r1)   0.0022s    461.4
 512 bits ecdh (brainpoolP512t1)   0.0021s    466.2
 253 bits ecdh (X25519)   0.0001s  16138.0
 448 bits ecdh (X448)   0.0009s   1120.5
                              sign    verify    sign/s verify/s
 253 bits EdDSA (Ed25519)   0.0001s   0.0003s   7197.1   3389.7
 456 bits EdDSA (Ed448)   0.0022s   0.0010s    446.2   1047.3
                              sign    verify    sign/s verify/s
 256 bits SM2 (CurveSM2)   0.0006s   0.0006s   1637.3   1795.8
                       op     op/s
2048 bits ffdh   0.0006s   1762.3
3072 bits ffdh   0.0013s    791.5
4096 bits ffdh   0.0026s    382.9
6144 bits ffdh   0.0060s    165.5
8192 bits ffdh   0.0123s     81.3
```
