### PR TITLE
add 'six' python package to add/renew certs via Gandi DNS provider

### DIFF
--- a/docker/Dockerfile.certbot
+++ b/docker/Dockerfile.certbot
@@ -35,7 +35,7 @@ ENV PATH="/opt/certbot/bin:$PATH"
 RUN curl -L 'https://bootstrap.pypa.io/get-pip.py' | python3
 
 RUN pip install --no-cache-dir --upgrade pyopenssl \
-	&& pip install --no-cache-dir cffi certbot cryptography \
+	&& pip install --no-cache-dir cffi certbot cryptography six \
 	&& pip install tldextract zope
 
 #############


### PR DESCRIPTION
Hello, there was a missing python package as described here : https://github.com/NginxProxyManager/nginx-proxy-manager/issues/4097